### PR TITLE
Migrate to PostCSS 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "postcss": "^7.0.6",
     "postcss-values-parser": "^2.0.0",
     "svgo": "^1.1.1",
     "xmldoc": "^1.1.2"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",
@@ -42,7 +44,8 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-dev": "^2.0.0",
-    "postcss-tape": "^3.0.0",
+    "postcss": "^8.0.0",
+    "postcss-tape": "^6.0.0",
     "pre-commit": "^1.2.2",
     "rollup": "^0.67.3",
     "rollup-plugin-babel": "^4.0.3"

--- a/src/index.js
+++ b/src/index.js
@@ -1,44 +1,55 @@
 /* Tooling
 /* ========================================================================== */
 
-// external tooling
-import postcss from 'postcss';
-
 // internal tooling
 import transpileDecl from './lib/transpile-decl';
 
 /* Inline SVGs
 /* ========================================================================== */
 
-export default postcss.plugin('postcss-svg-fragments', opts => (css, result) => {
-	// svg promises array
-	const promises = [];
+const plugin = opts => {
+	return {
+		postcssPlugin: 'postcss-svg',
+		prepare (result) {
+			// svg promises array
+			const promises = [];
 
-	// plugin options
-	const normalizedOpts = {
-		// additional directories to search for SVGs
-		dirs: 'dirs' in Object(opts) ? [].concat(opts.dirs) : [],
-		// whether to encode as utf-8
-		utf8: 'utf8' in Object(opts) ? Boolean(opts.utf8) : true,
-		// whether and how to compress with svgo
-		svgo: 'svgo' in Object(opts) ? Object(opts.svgo) : false
-	};
+			// plugin options
+			const normalizedOpts = {
+				// additional directories to search for SVGs
+				dirs: 'dirs' in Object(opts) ? [].concat(opts.dirs) : [],
+				// whether to encode as utf-8
+				utf8: 'utf8' in Object(opts) ? Boolean(opts.utf8) : true,
+				// whether and how to compress with svgo
+				svgo: 'svgo' in Object(opts) ? Object(opts.svgo) : false
+			};
 
-	// cache of file content and json content promises
-	const cache = {};
+			// cache of file content and json content promises
+			const cache = {};
 
-	// for each declaration in the stylesheet
-	css.walkDecls(decl => {
-		// if the declaration contains a url()
-		if (containsUrlFunction(decl)) {
-			// transpile declaration parts
-			transpileDecl(result, promises, decl, normalizedOpts, cache);
+			return {
+				Once (root) {
+					// for each declaration in the stylesheet
+					root.walkDecls(decl => {
+						// if the declaration contains a url()
+						if (containsUrlFunction(decl)) {
+							// transpile declaration parts
+							transpileDecl(result, promises, decl, normalizedOpts, cache);
+						}
+					});
+				},
+				async OnceExit () {
+					// wait for chained svg promises array
+					await Promise.all(promises);
+				}
+			};
 		}
-	});
+	}
+}
 
-	// return chained svg promises array
-	return Promise.all(promises);
-});
+plugin.postcss = true;
+
+export default plugin;
 
 /* Inline Tooling
 /* ========================================================================== */


### PR DESCRIPTION
This PR updates the plugin API to be compatible with PostCSS 8.

Would you prefer a PostCSS version detection similar to what `postcss-tape` is doing, @jonathantneal?